### PR TITLE
Add BOSL2 package under /pub/std/metric/bosl2

### DIFF
--- a/std/metric/partcad.yaml
+++ b/std/metric/partcad.yaml
@@ -7,6 +7,10 @@ import:
     type: git
     url: https://github.com/partcad/partcad-cqwarehouse/
     relPath: metric.yaml
+  bosl2:
+    desc: Parametric BOSL2 shapes, gears, threading and hardware (Belfry OpenSCAD Library v2)
+    type: git
+    url: https://github.com/partcad/partcad-bosl2/
   m:
     desc: Standard M* interfaces
     type: git


### PR DESCRIPTION
## Summary

Adds [`partcad/partcad-bosl2`](https://github.com/partcad/partcad-bosl2) to the index, imported at `/pub/std/metric/bosl2` — side by side with `cqwarehouse` in `std/metric/partcad.yaml`.

BOSL2 (the Belfry OpenSCAD Library v2) is exposed as **~69 parametric parts across 12 categories** (`shapes3d`, `gears`, `threading`, `screws`, `metric_screws`, `nema_steppers`, `ball_bearings`, `linear_bearings`, `joiners`, `cubetruss`, `bottlecaps`, `walls`). Unlike cqwarehouse (which enumerates parts in YAML), it is served lazily by an **external repository plugin** that generates a part per renderable BOSL2 module by parsing its signature.

Parts resolve as `//pub/std/metric/bosl2/<category>:<module>`, e.g.:

```shell
pc inspect //pub/std/metric/bosl2/shapes3d:cuboid
pc inspect -p teeth=30 //pub/std/metric/bosl2/gears:spur_gear
```

## Requirements / notes

- Uses the `external` dependency type and the `repositories` section, so it requires a PartCAD release that includes **plugin-backed packages (partcad#457)** and **parametric OpenSCAD parts (#459)** — both landed on `devel`.
- BOSL2 source (BSD-2-Clause) is **not vendored**; the plugin downloads it on demand at build time into a local cache, so first use needs network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)