### PR TITLE
Add LEGO/LDraw parts under /pub/universe/lego

### DIFF
--- a/universe/partcad.yaml
+++ b/universe/partcad.yaml
@@ -1,0 +1,12 @@
+desc: |
+  Packages describing the "universe" of real-world product ecosystems.
+cover:
+  package: lego
+
+import:
+  # The LDraw parts library (LEGO-compatible parts) exposed as parametric
+  # PartCAD parts. Published at //pub/universe/lego/ldraw.
+  lego:
+    desc: LEGO parts from the LDraw library, as parametric PartCAD parts
+    type: git
+    url: https://github.com/partcad/partcad-ldraw/


### PR DESCRIPTION
## Summary

Adds a new `universe/` section and imports [`partcad/partcad-ldraw`](https://github.com/partcad/partcad-ldraw) as `lego`, publishing the **LDraw parts library** at `/pub/universe/lego/ldraw`.

Each LDraw category becomes a sub-package and every part is a parametric `:ldraw` part meshed from the LDraw `.dat` on demand:

```shell
pc list packages //pub/universe/lego/ldraw          # categories
pc list parts    //pub/universe/lego/ldraw/Brick    # complete part list (paginated, cached)
pc inspect       //pub/universe/lego/ldraw/Brick:3001
```

## How it maps

`partcad-ldraw`'s root package is `//pub/universe/lego` (it holds the `ldraw` external dependency), so importing it as `lego` under `/pub/universe` mounts it at `/pub/universe/lego`, with the library at `/pub/universe/lego/ldraw`.

## Requirements / notes

- Uses the `external` package mechanism and a `partType`, so it requires a PartCAD release that includes plugin-backed packages (partcad#457) and **partTypes** (partcad#469).
- LDraw parts are **not** vendored; the plugin fetches categories, part lists and `.dat` geometry from ldraw.org on demand and caches them. First use needs network access.
- Parts remain under their own per-part LDraw licenses (CC BY 4.0 / CCAL), recorded in each part's `.dat` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)