### PR TITLE
Use the // global path convention for the index root

### DIFF
--- a/partcad.yaml
+++ b/partcad.yaml
@@ -1,4 +1,4 @@
 partcad: ">=0.8.0"
-name: /pub
+name: //pub
 
 # Before adding your own packages, browse sub-folders to find the most appropriate parent package.


### PR DESCRIPTION
The root package declared itself as `/pub`, which PartCAD accepts only through the backward-compatibility shim that warns single-slash root paths are deprecated.

Every package path in the index derives from this name, so the warning fired for each one:

```
root=/pub    →  /pub/consumer: using '/' as the root package path is deprecated. Use '//' instead.
root=//pub   →  (silent)
```

Both spellings resolve — the shim normalizes `/pub` to `//pub` — so this is deprecation removal, not a bug fix. What changes is that the index now hands out `//pub/std/metric/m` instead of `/pub/std/metric/m` as the canonical spelling of every package it publishes.

## Verification

Loaded with PartCAD 0.8.33 against the local tree:

- root package name `//pub`, `broken=False`
- all 53 distinct package paths referenced across the index and every repository it references resolve against the package universe built from the index (129 known paths)
- 0 references still tripping the deprecation shim, checked by running each one through PartCAD's own `resolve_resource_path`

Companion PRs convert the ten referenced `partcad`-org packages; the six `openvmp`-org packages are already merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X42sdohAMTb2XVscT4zNvh)_