### PR TITLE
Publish the standard plastics material catalogue

### DIFF
--- a/std/manufacturing/material/partcad.yaml
+++ b/std/manufacturing/material/partcad.yaml
@@ -1,0 +1,11 @@
+desc: |
+  What parts are made of. A package here catalogues materials, which parts
+  refer to by their "material" parameter as //pub/std/manufacturing/material/<family>:<name>.
+cover:
+  package: plastic
+
+dependencies:
+  plastic:
+    desc: Standard plastics (PLA, ABS, Nylon)
+    type: git
+    url: https://github.com/partcad/std-manufacturing-materials-plastic

--- a/std/manufacturing/partcad.yaml
+++ b/std/manufacturing/partcad.yaml
@@ -1,0 +1,5 @@
+desc: |
+  Packages describing how things are made: the materials they are made of,
+  and the processes that make them.
+cover:
+  package: material


### PR DESCRIPTION
`//pub/std/manufacturing/material/plastic` is the path the PartCAD documentation names for standard materials (`configuration.rst`, on the `material` parameter), and the path `examples/provider_manufacturer` already uses as the default `material` of its part:

```yaml
material:
  type: string
  default: //pub/std/manufacturing/material/plastic:pla
```

Nothing in the index published it, so that reference dangled. Harmlessly so far — until the `material` object type, nothing resolved it; the value was a string compared for equality against a provider's declared capabilities.

This adds the `std/manufacturing/material` sub-tree and indexes `partcad/std-manufacturing-materials-plastic` under it, which is what makes the reference resolve.

## Verified

Loaded through the real index layout, with the catalogue resolved locally:

```
index root name : //pub
THE reference   : //pub/std/manufacturing/material/plastic:pla
  package       : //pub/std/manufacturing/material/plastic
  material      : PLA / Polylactic Acid
  density       : 0.00132 g/mm^3
  mass 1000mm^3 : 1.32 g
```

## Depends on

- partcad/partcad#601 — introduces the `material` object type. Without it the indexed package loads and publishes nothing.
- partcad/std-manufacturing-materials-plastic#1 — converts the catalogue to `//pub/...` and pins the version that has the object type. **Merge that first**, since this entry tracks its default branch and does not pin a revision.

Split out of partcad/partcad-index#8 (the root package name fix), which is independent and ready now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X42sdohAMTb2XVscT4zNvh)_